### PR TITLE
Release 0.2.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
           uses: "actions/checkout@v4.2.2"
 
         - name: "Set up Python"
-          uses: actions/setup-python@v5.2.0
+          uses: actions/setup-python@v5.3.0
           with:
             python-version: "3.12"
             cache: "pip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,6 @@ jobs:
           zip modbus_logo.zip -r ./
 
       - name: "Upload the ZIP file to the release"
-        uses: "softprops/action-gh-release@v2.0.8"
+        uses: "softprops/action-gh-release@v2.0.9"
         with:
           files: ${{ github.workspace }}/custom_components/modbus_logo/modbus_logo.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,6 @@ jobs:
           zip modbus_logo.zip -r ./
 
       - name: "Upload the ZIP file to the release"
-        uses: "softprops/action-gh-release@v2.0.9"
+        uses: "softprops/action-gh-release@v2.1.0"
         with:
           files: ${{ github.workspace }}/custom_components/modbus_logo/modbus_logo.zip

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Continuing in the reading of this file you'll find the documentation for the add
 
 ## Supported entity
 
-Currently (HA core v2024.6.0) all entities already supported by official component are supported:
+Currently (HA core v2024.11.0) all entities already supported by official component are supported:
 
 - binary_sensor
 - climate
@@ -33,7 +33,7 @@ Currently (HA core v2024.6.0) all entities already supported by official compone
 
 ## Prerequisites
 
-- [Home Assistant (hass)](https://www.home-assistant.io/) >= 2024.6
+- [Home Assistant (hass)](https://www.home-assistant.io/) >= 2024.11
 - [pymodbus](https://github.com/pymodbus-dev/pymodbus) == 3.6.8 will load automatically.
 - [HACS](https://hacs.xyz/docs/setup/download/)
 

--- a/custom_components/modbus_logo/__init__.py
+++ b/custom_components/modbus_logo/__init__.py
@@ -27,7 +27,6 @@ from homeassistant.components.modbus.const import (
     CONF_INPUT_TYPE,
     CONF_MSG_WAIT,
     CONF_PARITY,
-    CONF_RETRIES,
     CONF_STATE_OFF,
     CONF_STATE_ON,
     CONF_STOPBITS,
@@ -96,7 +95,6 @@ MODBUS_SCHEMA = vol.Schema(
         vol.Optional(CONF_NAME, default=DEFAULT_HUB): cv.string,
         vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
         vol.Optional(CONF_DELAY, default=0): cv.positive_int,
-        vol.Optional(CONF_RETRIES): cv.positive_int,
         vol.Optional(CONF_MSG_WAIT): cv.positive_int,
         vol.Optional(CONF_BINARY_SENSORS): vol.All(
             cv.ensure_list, [mb_component.BINARY_SENSOR_SCHEMA]

--- a/custom_components/modbus_logo/manifest.json
+++ b/custom_components/modbus_logo/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pymodbus==3.6.9"
   ],
-  "version": "0.2.1"
+  "version": "0.2.2"
 }

--- a/custom_components/modbus_logo/manifest.json
+++ b/custom_components/modbus_logo/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pymodbus==3.6.9"
   ],
-  "version": "0.2.2"
+  "version": "0.2.3"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "Modbus Logo!8",
     "hide_default_branch": true,
-    "homeassistant": "2024.6.0",
+    "homeassistant": "2024.11.0",
     "render_readme": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.9.0
-homeassistant==2024.6.0
+homeassistant==2024.11.0
 pip>=21.0,<24.4
 ruff==0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.9.0
 homeassistant==2024.11.0
 pip>=21.0,<24.4
-ruff==0.7.3
+ruff==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.9.0
 homeassistant==2024.6.0
-pip>=21.0,<24.3
+pip>=21.0,<24.4
 ruff==0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.9.0
 homeassistant==2024.11.0
 pip>=21.0,<24.4
-ruff==0.7.2
+ruff==0.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-colorlog==6.8.2
+colorlog==6.9.0
 homeassistant==2024.6.0
 pip>=21.0,<24.3
 ruff==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.9.0
 homeassistant==2024.6.0
 pip>=21.0,<24.3
-ruff==0.7.0
+ruff==0.7.2


### PR DESCRIPTION
This pull request includes several updates to the `modbus_logo` custom component for Home Assistant. The changes include version updates, removal of an unused configuration option, and adjustments to the release workflow.

### Version Updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L27-R27): Updated the `softprops/action-gh-release` action from version `v2.0.9` to `v2.1.0`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R24): Updated the Home Assistant core version from `2024.6.0` to `2024.11.0`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R36)
* [`hacs.json`](diffhunk://#diff-2004f3033aaa650b74a155b56a1e6110e85583824c83f3cb5a0c2856bd00483fL4-R4): Updated the Home Assistant core version from `2024.6.0` to `2024.11.0`.
* [`custom_components/modbus_logo/manifest.json`](diffhunk://#diff-5ceda8531429f1b01fc7d18a6aaad9e891dc55f88d442fcee5aa518b6d63c20cL14-R14): Updated the `pymodbus` requirement to version `3.6.9` and the component version to `0.2.3`.

### Configuration Changes:
* [`custom_components/modbus_logo/__init__.py`](diffhunk://#diff-61360a2cb0194275bfc2de50353c51bafcfe4f131a3e39258803df1896b897afL30): Removed the `CONF_RETRIES` configuration option as it is no longer used. [[1]](diffhunk://#diff-61360a2cb0194275bfc2de50353c51bafcfe4f131a3e39258803df1896b897afL30) [[2]](diffhunk://#diff-61360a2cb0194275bfc2de50353c51bafcfe4f131a3e39258803df1896b897afL99)