### PR TITLE
Remove unnecessary deps from custom component

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,18 @@
+name: Check
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * 5"
+jobs:
+  home-assistant:
+    name: Home Assistant Core Configuration Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out configuration from GitHub
+        uses: actions/checkout@v3
+      - name: 🚀 Run Home Assistant Configuration Check
+        uses: frenck/action-home-assistant@v1
+        with:
+          path: "./config"

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -11,6 +11,13 @@ logger:
   logs:
     custom_components.modbus_logo: debug
 
-debugpy:
-  start: true
-  wait: true
+modbus_logo:
+  - name: plc
+    type: tcp
+    host: 127.0.0.1
+    port: 502
+    lights:
+      - name: test
+        address: 1
+        write_type: coil
+

--- a/custom_components/modbus_logo/manifest.json
+++ b/custom_components/modbus_logo/manifest.json
@@ -8,8 +8,5 @@
   "documentation": "https://github.com/nos86/hacs-modbus-logo",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/nos86/hacs-modbus-logo/issues",
-  "requirements": [
-    "pymodbus==3.6.9"
-  ],
   "version": "0.2.3"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
 colorlog==6.9.0
-homeassistant==2024.11.0
+homeassistant
 pip>=21.0,<24.4
 ruff==0.8.6
+pymodbus
+hassil
+home-assistant-frontend
+home-assistant-intents
+zeroconf


### PR DESCRIPTION
This pull request includes several changes to the configuration and setup of the Home Assistant project. The most important changes are the addition of a new GitHub Actions workflow for configuration checks, modifications to the `configuration.yaml` file, and updates to the `manifest.json` file for the `modbus_logo` custom component.

New GitHub Actions workflow:

* [`.github/workflows/check.yml`](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428R1-R18): Added a new workflow to perform Home Assistant Core Configuration Checks on push, pull request, workflow dispatch, and a scheduled cron job.

Configuration changes:

* [`config/configuration.yaml`](diffhunk://#diff-79a352dfb73f73e7c54f79d5e0fe23bcebdd4cd53ee957b1773c4e1a380a64fdL14-R23): Removed `debugpy` configuration and added `modbus_logo` configuration with details for a PLC connection and a light entity.

Manifest updates:

* [`custom_components/modbus_logo/manifest.json`](diffhunk://#diff-5ceda8531429f1b01fc7d18a6aaad9e891dc55f88d442fcee5aa518b6d63c20cL11-L13): Removed the `pymodbus` requirement from the manifest file.